### PR TITLE
Surround newline literal in stack trace with double-quotes

### DIFF
--- a/lib/chef/handler/campfire.rb
+++ b/lib/chef/handler/campfire.rb
@@ -37,7 +37,7 @@ class Chef
                  end
 
           room.speak([node.hostname, run_status.formatted_exception].join(' '))
-          room.paste(Array(backtrace).join('\n'))
+          room.paste(Array(backtrace).join("\n"))
         end
       end
     end


### PR DESCRIPTION
Stacktraces pasted to Basecamp aren't formatted correctly because the newline literal was incorrectly enclosed in single quotes rather than double quotes.
